### PR TITLE
Fix checkDiff() on windows

### DIFF
--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -181,16 +181,12 @@ module.exports = class Deploy
 			fs.writeFileSync @revisionPath, @local_hash
 
 			# If the remote revision file exists, let's get it's content
-			if typeof data is "string"
-				@remote_hash = data
-				@checkDiff @remote_hash, @local_hash
-			else
-				data.on "data", (e) =>
-					data.end()
-					@remote_hash = e.toString()
+			data.on "data", (e) =>
+				data.end()
+				@remote_hash = e.toString()
 
-					# Get the diff tree between the local and remote revisions 
-					@checkDiff @remote_hash, @local_hash
+				# Get the diff tree between the local and remote revisions
+				@checkDiff @remote_hash, @local_hash
 
 	# Get the diff tree between the local and remote revisions 
 	checkDiff: (old_rev, new_rev) ->


### PR DESCRIPTION
This attempts to fix issue #13.

I've removed single quotes from pretty formatting, because they seem to be causing this problem in `git diff`. As it seems the quotes are unnecessary when comparing two commit hashes both on Windows and *nix systems.

I've also refactored reading of the remote .rev file, since it's always coming as raw binary data.

Please feel free to criticize and reject this for whatever reason.
