### PR TITLE
[bugfix] Make default dploy.yaml use only spaces.

### DIFF
--- a/generator/dploy.yaml
+++ b/generator/dploy.yaml
@@ -1,5 +1,5 @@
 dev:
-	scheme: ftp
+    scheme: ftp
     host: ftp.my-dev-server.com
     port: 21
     user: user
@@ -10,7 +10,7 @@ dev:
         remote: public_html/
 
 stage:
-	scheme: ftp
+    scheme: ftp
     host: ftp.my-stage-server.com
     port: 21
     user: user
@@ -21,7 +21,7 @@ stage:
         remote: public_html/
 
 live:
-	scheme: ftp
+    scheme: ftp
     host: ftp.my-live-server.com
     port: 21
     user: user


### PR DESCRIPTION
generator/dploy.yaml had a tab amongst spaces, which is not allowed, and was causing an error when trying to read it.
