### PR TITLE
Include dot files in `minimatch` exclude. Should fix #44.

### DIFF
--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -357,7 +357,7 @@ module.exports = class Deploy
 			return no if name.indexOf(@config.path.local) < 0
 
 		for exclude in @config.exclude
-			return no if minimatch(name, exclude)
+			return no if minimatch(name, exclude, { dot: true })
 
 		yes
 


### PR DESCRIPTION
Some issues surrounding dot files being included when they shouldn't be. It appears that it was because `minimatch` does not include dot files by default. This changes that.
